### PR TITLE
Fixes #12600 - Adding only app/lib folder to autoload paths

### DIFF
--- a/lib/foreman_deployments/engine.rb
+++ b/lib/foreman_deployments/engine.rb
@@ -4,7 +4,7 @@ require 'foreman_deployments/monkey_patches'
 
 module ForemanDeployments
   class Engine < ::Rails::Engine
-    config.autoload_paths += Dir["#{config.root}/app/**/"]
+    config.autoload_paths += Dir["#{config.root}/app/*/"]
     config.autoload_paths += ["#{config.root}/test/"]
 
     # Add any db migrations


### PR DESCRIPTION
@tstrachota: this makes foreman_deployments work in production environment and resolves issues with not finding defined constants.
